### PR TITLE
Vision transformer implementation and framework updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ COPY ./datasets/datasets ./NapoleonZero/datasets
 
 # TODO: move up
 RUN pip install einops
+RUN pip install jupyterlab
 
 COPY ./src ./NapoleonZero/src
 RUN chmod +x ./NapoleonZero/src/napoleonzero-torch.py
 
-RUN pip install jupyterlab
 
 # CMD ["python3", "./NapoleonZero/src/napoleonzero-torch.py"]
 WORKDIR /root/NapoleonZero/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN pip install --upgrade wandb && \
 WORKDIR /root
 RUN mkdir -p ./NapoleonZero
 COPY ./datasets/datasets ./NapoleonZero/datasets
+
+# TODO: move up
+RUN pip install einops
+
 COPY ./src ./NapoleonZero/src
 RUN chmod +x ./NapoleonZero/src/napoleonzero-torch.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,9 @@ RUN pip install einops
 COPY ./src ./NapoleonZero/src
 RUN chmod +x ./NapoleonZero/src/napoleonzero-torch.py
 
-CMD ["python3", "./NapoleonZero/src/napoleonzero-torch.py"]
+RUN pip install jupyterlab
+
+# CMD ["python3", "./NapoleonZero/src/napoleonzero-torch.py"]
+WORKDIR /root/NapoleonZero/src
+CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root"]
+

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+# --shm-size 8G \
 
 docker run -it \
   --rm \
   --gpus all \
   --runtime=nvidia \
-  --shm-size 8G \
+  --ipc=host \
   --env CUBLAS_WORKSPACE_CONFIG=:4096:8 \
   training \
   $@

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@ docker run -it \
   --gpus all \
   --runtime=nvidia \
   --ipc=host \
+  -p 8888:8888 \
   --env CUBLAS_WORKSPACE_CONFIG=:4096:8 \
   training \
   $@

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -89,7 +89,7 @@ class LRSchedulerCallback(TrainingCallback):
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
         self.lr_warmup = LinearLR(self.optimizer, start_factor=0.001, total_iters=self.warmup_steps)
-        self.lr_decay = ReduceLROnPlateau(self.optimizer, mode='min', factor=0.5, patience=10)
+        self.lr_decay = ReduceLROnPlateau(self.optimizer, mode='min', factor=0.5, patience=5)
     
     def on_train_start(self, state):
         super().on_train_start(state)
@@ -102,7 +102,7 @@ class LRSchedulerCallback(TrainingCallback):
 
     def on_validation_end(self, state):
         super().on_validation_end(state)
-        val_loss = state.get_state('val_loss')
-        if val_loss:
-            self.lr_decay.step(state.val_loss)
-            state.update_state('lr', self.lr_decay.get_last_lr()[0])
+        val_loss = state.get_last_metric('val_loss')
+        if val_loss is not None:
+            self.lr_decay.step(val_loss)
+            state.update_state('lr', self.optimizer.param_groups[0]['lr'])

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -128,7 +128,7 @@ class WandbCallback(TrainingCallback):
                 entity=self.entity,
                 config=self.config,
                 tags=self.tags,
-                save_code=self.save_code
+                save_code=self.save_code,
                 reinit=True)
 
     def on_train_end(self, state):
@@ -148,10 +148,10 @@ class WandbCallback(TrainingCallback):
         batch = state.get_state('batch')
         if self.log and self.batch_frequency and batch \
                     and batch % self.batch_frequency == 0:
-            wandb.log(state.get_states() | state.get_last_metrics(), commit=True)
+            wandb.log({**state.get_states(), **state.get_last_metrics()}, commit=True)
 
     def on_validation_end(self, state):
         super().on_validation_end(state)
         if self.log:
-            wandb.log(state.get_states() | state.get_last_metrics(), commit=True)
+            wandb.log({**state.get_states(), **state.get_last_metrics()}, commit=True)
 

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -1,0 +1,108 @@
+import pkbar # progress bar for pytorch
+import torch
+from torch import nn
+from torch.optim.lr_scheduler import LinearLR, ReduceLROnPlateau
+from training import TrainingLoop
+
+class TrainingCallback():
+    """ Training Callback base class """
+    def __init__(self):
+        return
+
+    def on_train_start(self, state):
+        return
+
+    def on_train_end(self, state):
+        return
+
+    def on_train_batch_start(self, state):
+        return
+
+    def on_train_batch_end(self, state):
+        return
+
+    def on_train_epoch_start(self, state):
+        return
+
+    def on_train_epoch_end(self, state):
+        return
+
+    def on_validation_batch_start(self, state):
+        return
+
+    def on_validation_batch_end(self, state):
+        return
+
+    def on_validation_start(self, state):
+        return
+
+    def on_validation_end(self, state):
+        return
+
+class ProgressbarCallback(TrainingCallback):
+    kbar: pkbar.Kbar
+
+    def __init__(self, epochs, width=20):
+        super().__init__()
+        self.epochs = epochs
+        self.width = width
+
+    def on_train_epoch_start(self, state):
+        super().on_train_epoch_start(state)
+        epoch = state.get_state('epoch')
+        num_batches = state.get_state('batches')
+        ################################### Initialization ########################################
+        if epoch is not None and num_batches is not None:
+            self.kbar = pkbar.Kbar(
+                    target=num_batches,
+                    num_epochs=self.epochs,
+                    epoch=epoch,
+                    width=self.width,
+                    always_stateful=False,
+                    stateful_metrics=['lr'])
+        # By default, all metrics are averaged over time. If you don't want this behavior, you could either:
+        # 1. Set always_stateful to True, or
+        # 2. Set stateful_metrics=["loss", "rmse", "val_loss", "val_rmse"], Metrics in this list will be displayed as-is.
+        # All others will be averaged by the progbar before display.
+        ###########################################################################################
+    
+    def on_train_batch_end(self, state):
+        super().on_train_batch_end(state)
+        # TODO: use self.metrics and self.state to update the progress bar
+        batch = state.get_state('batch')
+        lr = state.get_state('lr')
+        loss = state.get_last_metric('loss')
+        if batch is not None and loss and lr:
+            self.kbar.update(batch, values=[('loss', loss), ('lr', lr)])
+
+    def on_validation_end(self, state):
+        super().on_validation_end(state)
+        # TODO: use self.metrics to update the progress bar
+        val_loss = state.get_last_metric('val_loss')
+        if val_loss is not None:
+            self.kbar.add(1, values=[('val_loss', val_loss)])
+
+
+class LRSchedulerCallback(TrainingCallback):
+    def __init__(self, optimizer, warmup_steps=1000):
+        super().__init__()
+        self.optimizer = optimizer
+        self.warmup_steps = warmup_steps
+        self.lr_warmup = LinearLR(self.optimizer, start_factor=0.001, total_iters=self.warmup_steps)
+        self.lr_decay = ReduceLROnPlateau(self.optimizer, mode='min', factor=0.5, patience=10)
+    
+    def on_train_start(self, state):
+        super().on_train_start(state)
+        state.update_state('lr', self.lr_warmup.get_last_lr()[0])
+
+    def on_train_batch_end(self, state):
+        super().on_train_batch_end(state)
+        self.lr_warmup.step()
+        state.update_state('lr', self.lr_warmup.get_last_lr()[0])
+
+    def on_validation_end(self, state):
+        super().on_validation_end(state)
+        val_loss = state.get_state('val_loss')
+        if val_loss:
+            self.lr_decay.step(state.val_loss)
+            state.update_state('lr', self.lr_decay.get_last_lr()[0])

--- a/src/datasets/BitboardDataset.py
+++ b/src/datasets/BitboardDataset.py
@@ -61,7 +61,6 @@ class BitboardDataset(Dataset):
         if self.debug:
             print('Dataset initialized')
 
-
     def _join_datasets(self, dir, glob_str):
         dfs = []
         name_glob = dir + '/' + glob_str

--- a/src/datasets/BitboardDataset.py
+++ b/src/datasets/BitboardDataset.py
@@ -29,8 +29,12 @@ class BitboardDataset(Dataset):
         self.dataset = self._join_datasets(dir, filename)
         # If preload flag is set, load and preprocess dataset in memory
         if self.preload:
-            self.dataset, self.aux, self.scores = self._preprocess_ds(self.dataset)
+            features, self.aux, self.scores = self._preprocess_ds(self.dataset)
+            del self.dataset
             gc.collect()
+            self.dataset = features
+
+        gc.collect()
 
 
     def _join_datasets(self, dir, glob_str):
@@ -115,10 +119,10 @@ class BitboardDataset(Dataset):
         if self.debug:
             print(self.dataset.info(memory_usage='deep'))
 
-        np_dataset = ds.iloc[:, :-4].values
-        np_dataset = np.array([np.concatenate(bs).reshape(12, 8, 8) for bs in np_dataset])
-        aux = ds.iloc[:, -4:-1].values
-        scores = ds.iloc[:, -1].values
+        np_dataset = ds.iloc[:, :-4].copy().values
+        np_dataset = np.array([np.concatenate(bs).reshape(12, 8, 8).copy() for bs in np_dataset])
+        aux = ds.iloc[:, -4:-1].copy().values
+        scores = ds.iloc[:, -1].copy().values
         gc.collect()
 
         return np_dataset, aux, scores

--- a/src/datasets/BitboardDataset.py
+++ b/src/datasets/BitboardDataset.py
@@ -4,6 +4,7 @@ import torch
 import glob
 import gc
 from torch.utils.data import Dataset
+from multiprocessing import Pool
 
 def string_to_matrix(bitboard):
     return np.array([b for b in bitboard], dtype=np.uint8).reshape(8,8).copy()
@@ -15,26 +16,50 @@ class BitboardDataset(Dataset):
     """ Represents a generic Dataset of games
         TODO: implement transform and target_transform
     """
-    def __init__(self, dir, filename, glob=True, preload=True, fraction=1.0, transform=None, target_transform=None, seed=42, debug=False):
+    def __init__(self,
+                 dir,
+                 filename,
+                 glob=True,
+                 preload=True,
+                 preload_chunks=True,
+                 fraction=1.0,
+                 transform=None,
+                 target_transform=None,
+                 seed=42,
+                 debug=False):
         self.dir = dir
         self.glob = glob
         self.preload = preload
+        self.preload_chunks = preload_chunks
         self.fraction = fraction
         self.transform = transform
         self.target_transform = target_transform
         self.seed = seed
         self.debug = debug
 
-        # Load dataset from disk
-        self.dataset = self._join_datasets(dir, filename)
-        # If preload flag is set, load and preprocess dataset in memory
-        if self.preload:
-            features, self.aux, self.scores = self._preprocess_ds(self.dataset)
-            del self.dataset
+        # Load and process dataset leveraging multiprocessing in order to 
+        # avoid memory retention: create a pool with only one process
+        # and replace it after each task submitted so that the used memory
+        # is freed
+        with Pool(processes=1, maxtasksperchild=1) as pool:
+            # Load dataset from disk
+            result = pool.apply_async(self._join_datasets, (dir, filename,))
+            ds = result.get()
             gc.collect()
-            self.dataset = features
+
+            # If preload flag is set, load and preprocess dataset in memory
+            if self.preload:
+                result = pool.apply_async(self._preprocess_ds, (ds,))
+                # features, aux, scores = result.get()
+                self.dataset, self.aux, self.scores = result.get()
+
+                del result
+                del ds
+                gc.collect()
 
         gc.collect()
+        if self.debug:
+            print('Dataset initialized')
 
 
     def _join_datasets(self, dir, glob_str):
@@ -44,6 +69,17 @@ class BitboardDataset(Dataset):
             files = glob.glob(name_glob)
         else:
             files = [name_glob]
+
+        # Sort filenames in ascending order
+        files = sorted(files)
+
+        # If preload_chunks = False, we only load the first self.fraction of
+        # the dataset chunks. Otherwise we load them all and the return only
+        # self.fraction of the whole dataset. By doing so we can perform an
+        # unbiased sampling of the dataset when preload_chunks = True.
+        if not self.preload_chunks:
+            files = files[:int(len(files)*self.fraction)]
+        
 
         # TODO: try pandas arrow string type
         dtypes = {
@@ -61,31 +97,29 @@ class BitboardDataset(Dataset):
                 17: 'float16'               # score in centipawns: [-inf, +inf]
                 }
 
-        df_merged = None
+        dfs = []
 
-        for filename in sorted(files):
+        for filename in files:
             if self.debug:
                 print(f"Loading {filename}")
 
             # use dtype=str when parsing the csv to avoid converting bitboards 
             # in integer values (e.g ....001 -> 1)
             df = pd.read_csv(filename, header=None, dtype=dtypes)
-
-            if df_merged is None:
-                df_merged = df
-            else:
-                df_merged = pd.concat([df_merged, df], axis=0, ignore_index=True)
-                del df
-                gc.collect()
-
-        gc.collect()
-        df_merged = self._filter_scores(df_merged, scaled=False)
+            dfs.append(df)
 
         if self.debug:
             print('Concatenating datasets')
+        df_merged = pd.concat(dfs, axis=0, ignore_index=True)
+        df_merged = self._filter_scores(df_merged, scaled=False)
+        gc.collect()
 
-        if self.fraction < 1.0:
+        
+        if self.fraction < 1.0 and self.preload_chunks:
+            if self.debug:
+                print('Sampling dataset')
             return df_merged.sample(frac=1, random_state=self.seed)[:int(len(df_merged)*self.fraction)]
+
         return df_merged
 
     def _filter_scores(self, ds, scaled=False):
@@ -106,26 +140,30 @@ class BitboardDataset(Dataset):
         # change black's score perspective: always evaluate white's position
         ds.iloc[(ds.iloc[:, 13] == 1).values, 17] *= -1.0
 
-        for i in range(1, 13):
-            if self.debug:
-                print(f"Processing bitboards for column {i}/12")
-                ds[i] = ds[i].apply(string_to_matrix)
-                gc.collect()
-
         ds.drop(ds.columns[[0, 16]], inplace=True, axis=1) # drop fen position and depth
         ds.reset_index(drop=True, inplace=True)
         gc.collect()
 
         if self.debug:
-            print(self.dataset.info(memory_usage='deep'))
+            print(ds.info(memory_usage='deep'))
 
-        np_dataset = ds.iloc[:, :-4].copy().values
-        np_dataset = np.array([np.concatenate(bs).reshape(12, 8, 8).copy() for bs in np_dataset])
-        aux = ds.iloc[:, -4:-1].copy().values
-        scores = ds.iloc[:, -1].copy().values
+        aux = ds.iloc[:, -4:-1].values.copy()
+        scores = ds.iloc[:, -1].values.copy()
+        #######################################################################
+        if self.debug:
+            print('Reshaping bitboards')
+
+        bitboards = ds.iloc[:, :-4].values.copy()
+        del ds
         gc.collect()
 
-        return np_dataset, aux, scores
+        bitboards = np.array([[string_to_matrix(b) for b in bs] for bs in bitboards])
+        #######################################################################
+
+        if self.debug:
+            print('Returning (copy of) dataset')
+        return bitboards, aux, scores
+    
 
     def _preprocess_row(self, row):
         row = row.copy()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,1 +1,2 @@
 from .cnn import CNN
+from .transformer import BitboardTransformer

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -139,20 +139,20 @@ class ViT(nn.Module):
 
 
 class BitboardTransformer(nn.Module):
-    def __init__(self):
+    def __init__(self, patch_size=2, dim=64, depth=12, heads=32, mlp_dim=256, dropout=0.1, emb_dropout=0.0):
         super(BitboardTransformer, self).__init__()
         self.vit = ViT(
                     image_size=8,
-                    patch_size=4,
+                    patch_size=patch_size,
                     num_classes=1,
-                    dim=64,
-                    depth=12,
-                    heads=32,
-                    mlp_dim=256,
+                    dim=dim,
+                    depth=depth,
+                    heads=heads,
+                    mlp_dim=mlp_dim,
                     channels=12,
                     pool='mean',
-                    dropout=0.1,
-                    emb_dropout=0.0
+                    dropout=dropout,
+                    emb_dropout=emb_dropout
                     )
 
     def forward(self, x, aux):

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -143,14 +143,16 @@ class BitboardTransformer(nn.Module):
         super(BitboardTransformer, self).__init__()
         self.vit = ViT(
                     image_size=8,
-                    patch_size=2,
+                    patch_size=4,
                     num_classes=1,
-                    dim=1024,
-                    depth=4,
-                    heads=8,
-                    mlp_dim=512,
+                    dim=64,
+                    depth=12,
+                    heads=32,
+                    mlp_dim=256,
                     channels=12,
-                    pool='mean'
+                    pool='mean',
+                    dropout=0.1,
+                    emb_dropout=0.0
                     )
 
     def forward(self, x, aux):

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -66,3 +66,24 @@ class ViT(nn.Module):
 
         x = self.to_latent(x)
         return self.mlp_head(x)
+
+
+class BitboardTransformer(nn.Module):
+    def __init__(self, patch_size=2, dim=64, depth=12, heads=32, mlp_dim=256, dropout=0.1, emb_dropout=0.0):
+        super(BitboardTransformer, self).__init__()
+        self.vit = ViT(
+                    image_size=8,
+                    patch_size=patch_size,
+                    num_classes=1,
+                    dim=dim,
+                    depth=depth,
+                    heads=heads,
+                    mlp_dim=mlp_dim,
+                    channels=12,
+                    pool='mean',
+                    dropout=dropout,
+                    emb_dropout=emb_dropout
+                    )
+
+    def forward(self, x, aux):
+        return self.vit(x, aux)

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -4,6 +4,9 @@ from torch import nn
 from einops import rearrange, repeat
 from einops.layers.torch import Rearrange
 
+def pair(t):
+    return t if isinstance(t, tuple) else (t, t)
+
 class ViT(nn.Module):
     def __init__(self, *, image_size, patch_size, num_classes, dim, depth, heads, mlp_dim, pool = 'cls', channels = 3, dim_head = 64, dropout = 0., emb_dropout = 0.):
         super().__init__()

--- a/src/models/transformer.py
+++ b/src/models/transformer.py
@@ -1,0 +1,159 @@
+import torch
+from torch import nn
+
+from einops import rearrange, repeat
+from einops.layers.torch import Rearrange
+
+# helpers
+
+def pair(t):
+    return t if isinstance(t, tuple) else (t, t)
+
+# classes
+
+class PreNorm(nn.Module):
+    def __init__(self, dim, fn):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+        self.fn = fn
+    def forward(self, x, **kwargs):
+        return self.fn(self.norm(x), **kwargs)
+
+class FeedForward(nn.Module):
+    def __init__(self, dim, hidden_dim, dropout = 0.):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim, hidden_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, dim),
+            nn.Dropout(dropout)
+        )
+    def forward(self, x):
+        return self.net(x)
+
+class Attention(nn.Module):
+    def __init__(self, dim, heads = 8, dim_head = 64, dropout = 0.):
+        super().__init__()
+        inner_dim = dim_head *  heads
+        project_out = not (heads == 1 and dim_head == dim)
+
+        self.heads = heads
+        self.scale = dim_head ** -0.5
+
+        self.attend = nn.Softmax(dim = -1)
+        self.to_qkv = nn.Linear(dim, inner_dim * 3, bias = False)
+
+        self.to_out = nn.Sequential(
+            nn.Linear(inner_dim, dim),
+            nn.Dropout(dropout)
+        ) if project_out else nn.Identity()
+
+    def forward(self, x):
+        qkv = self.to_qkv(x).chunk(3, dim = -1)
+        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b h n d', h = self.heads), qkv)
+
+        dots = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+
+        attn = self.attend(dots)
+
+        out = torch.matmul(attn, v)
+        out = rearrange(out, 'b h n d -> b n (h d)')
+        return self.to_out(out)
+
+class Transformer(nn.Module):
+    def __init__(self, dim, depth, heads, dim_head, mlp_dim, dropout = 0.):
+        super().__init__()
+        self.layers = nn.ModuleList([])
+        for _ in range(depth):
+            self.layers.append(nn.ModuleList([
+                PreNorm(dim, Attention(dim, heads = heads, dim_head = dim_head, dropout = dropout)),
+                PreNorm(dim, FeedForward(dim, mlp_dim, dropout = dropout))
+            ]))
+    def forward(self, x):
+        for attn, ff in self.layers:
+            x = attn(x) + x
+            x = ff(x) + x
+        return x
+
+class ViT(nn.Module):
+    def __init__(self, *, image_size, patch_size, num_classes, dim, depth, heads, mlp_dim, pool = 'cls', channels = 3, dim_head = 64, dropout = 0., emb_dropout = 0.):
+        super().__init__()
+        image_height, image_width = pair(image_size)
+        patch_height, patch_width = pair(patch_size)
+
+        assert image_height % patch_height == 0 and image_width % patch_width == 0, 'Image dimensions must be divisible by the patch size.'
+
+        num_patches = (image_height // patch_height) * (image_width // patch_width)
+        patch_dim = channels * patch_height * patch_width
+        assert pool in {'cls', 'mean'}, 'pool type must be either cls (cls token) or mean (mean pooling)'
+
+        self.to_patch_embedding = nn.Sequential(
+            Rearrange('b c (h p1) (w p2) -> b (h w) (p1 p2 c)', p1 = patch_height, p2 = patch_width),
+            nn.Linear(patch_dim, dim),
+        )
+
+        self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, dim))
+        self.cls_token = nn.Parameter(torch.randn(1, 1, dim))
+        self.dropout = nn.Dropout(emb_dropout)
+
+        # self.transformer = Transformer(dim, depth, heads, dim_head, mlp_dim, dropout)
+        self.transformer = nn.TransformerEncoder(
+                nn.TransformerEncoderLayer(
+                    d_model=dim,
+                    nhead=heads,
+                    dim_feedforward=mlp_dim,
+                    dropout=dropout,
+                    activation='gelu',
+                    norm_first=True,
+                    batch_first=True
+                    ),
+                num_layers=depth,
+                norm=nn.LayerNorm(dim)
+                )
+
+        self.pool = pool
+        self.to_latent = nn.Identity()
+
+        self.mlp_head = nn.Sequential(
+                nn.LayerNorm(dim + 3),
+                nn.Linear(dim + 3, num_classes)
+        )
+
+    def forward(self, img, aux):
+        x = self.to_patch_embedding(img)
+        b, n, _ = x.shape
+
+        cls_tokens = repeat(self.cls_token, '() n d -> b n d', b = b)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x += self.pos_embedding[:, :(n + 1)]
+        x = self.dropout(x)
+
+        x = self.transformer(x)
+
+        x = x.mean(dim = 1) if self.pool == 'mean' else x[:, 0]
+
+        x = self.to_latent(x)
+        x = torch.cat([x, aux], 1)
+        return self.mlp_head(x)
+
+
+class BitboardTransformer(nn.Module):
+    def __init__(self):
+        super(BitboardTransformer, self).__init__()
+        self.vit = ViT(
+                    image_size=8,
+                    patch_size=2,
+                    num_classes=1,
+                    dim=1024,
+                    depth=4,
+                    heads=8,
+                    mlp_dim=512,
+                    channels=12,
+                    pool='mean'
+                    )
+
+    def forward(self, x, aux):
+        return self.vit(x, aux)
+
+

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -28,7 +28,7 @@ def main():
     DRIVE_PATH = f'{sys.path[0]}/../datasets'
     DATASET = 'ccrl10M-depth1.csv.part*'
 
-    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, fraction=0.5, seed=SEED, debug=True)
+    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, preload_chunks=True, fraction=1.0, seed=SEED, debug=True)
     # model = CNN().to(device, memory_format=torch.channels_last)
     model = BitboardTransformer().to(device, memory_format=torch.channels_last)
     print(model)

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -9,6 +9,7 @@ from datasets import BitboardDataset
 from models import CNN, BitboardTransformer
 from training import TrainingLoop
 from callbacks import TrainingCallback, ProgressbarCallback, LRSchedulerCallback
+from callbacks import WandbCallback
 import sys
 
 def set_random_state(seed):
@@ -54,6 +55,9 @@ def main():
     optimizer = torch.optim.RAdam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
     epochs = 200
 
+    # TODO: compile configuration dictionary
+    config = { }
+
     training_loop = TrainingLoop(
             model,
             dataset,
@@ -70,7 +74,13 @@ def main():
             seed=SEED,
             callbacks=[
                 LRSchedulerCallback(optimizer, warmup_steps=1000),
-                ProgressbarCallback(epochs=epochs, width=20)
+                ProgressbarCallback(epochs=epochs, width=20),
+                WandbCallback(
+                    project_name='napoleon-zero-pytorch',
+                    entity='marco-pampaloni',
+                    config=config,
+                    tags=['initial-test-wandb']
+                    )
                 ]
             )
 

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -30,7 +30,16 @@ def main():
 
     dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, preload_chunks=True, fraction=1.0, seed=SEED, debug=True)
     # model = CNN().to(device, memory_format=torch.channels_last)
-    model = BitboardTransformer().to(device, memory_format=torch.channels_last)
+    patch_size = 4
+    model = BitboardTransformer(
+                patch_size=patch_size,
+                dim=(patch_size**2 * 16),
+                depth=10,
+                heads=16,
+                mlp_dim=256,
+                dropout=0.0,
+                emb_dropout=0.0
+            ).to(device, memory_format=torch.channels_last)
     print(model)
 
     loss_fn = nn.MSELoss()
@@ -44,7 +53,7 @@ def main():
             train_p=0.7,
             val_p=0.15,
             test_p=0.15,
-            batch_size=2**13,
+            batch_size=2**12,
             shuffle=True,
             device=device,
             mixed_precision=True,
@@ -52,7 +61,7 @@ def main():
             seed=SEED
             )
 
-    training_loop.run(epochs=100)
+    training_loop.run(epochs=200)
 
 if __name__ == '__main__':
     main()

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -17,6 +17,10 @@ def set_random_state(seed):
     torch.backends.cudnn.benchmark = False
     torch.use_deterministic_algorithms(True)
 
+def params_count(model):
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+
 def main():
     SEED = 42
     set_random_state(SEED)
@@ -33,14 +37,16 @@ def main():
     patch_size = 4
     model = BitboardTransformer(
                 patch_size=patch_size,
-                dim=(patch_size**2 * 16),
-                depth=10,
+                dim=(patch_size**2 * 8),
+                depth=8,
                 heads=16,
                 mlp_dim=256,
-                dropout=0.0,
+                dropout=0.05,
                 emb_dropout=0.0
             ).to(device, memory_format=torch.channels_last)
     print(model)
+    print(f'Number of parameters: {params_count(model)}')
+
 
     loss_fn = nn.MSELoss()
     optimizer = torch.optim.Adam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
@@ -50,9 +56,9 @@ def main():
             dataset,
             loss_fn,
             optimizer,
-            train_p=0.7,
-            val_p=0.15,
-            test_p=0.15,
+            train_p=0.95,
+            val_p=0.025,
+            test_p=0.025,
             batch_size=2**12,
             shuffle=True,
             device=device,

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -21,6 +21,9 @@ def set_random_state(seed):
 def params_count(model):
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
 
+def print_summary(model):
+    print(model)
+    print(f'Number of parameters: {params_count(model)}')
 
 def main():
     SEED = 42
@@ -33,7 +36,7 @@ def main():
     DRIVE_PATH = f'{sys.path[0]}/../datasets'
     DATASET = 'ccrl10M-depth1.csv.part*'
 
-    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, preload_chunks=False, fraction=0.02, seed=SEED, debug=True)
+    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, preload_chunks=True, fraction=1.0, seed=SEED, debug=True)
 
     patch_size = 4
     model = BitboardTransformer(
@@ -42,12 +45,10 @@ def main():
                 depth=8,
                 heads=16,
                 mlp_dim=256,
-                dropout=0.10,
+                dropout=0.2,
                 emb_dropout=0.0
             ).to(device, memory_format=torch.channels_last)
-    print(model)
-    print(f'Number of parameters: {params_count(model)}')
-
+    print_summary(model)
 
     loss_fn = nn.MSELoss()
     optimizer = torch.optim.RAdam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
@@ -61,7 +62,7 @@ def main():
             train_p=0.95,
             val_p=0.025,
             test_p=0.025,
-            batch_size=2**8,
+            batch_size=2**12,
             shuffle=True,
             device=device,
             mixed_precision=True,

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -49,7 +49,7 @@ def main():
 
 
     loss_fn = nn.MSELoss()
-    optimizer = torch.optim.Adam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
+    optimizer = torch.optim.RAdam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
 
     training_loop = TrainingLoop(
             model,

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 from datasets import BitboardDataset
-from models import CNN
+from models import CNN, BitboardTransformer
 from training import TrainingLoop
 import sys
 
@@ -28,8 +28,9 @@ def main():
     DRIVE_PATH = f'{sys.path[0]}/../datasets'
     DATASET = 'ccrl10M-depth1.csv.part*'
 
-    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, fraction=1.0, seed=SEED, debug=True)
-    model = CNN().to(device, memory_format=torch.channels_last)
+    dataset = BitboardDataset(dir=DRIVE_PATH, filename=DATASET, glob=True, preload=True, fraction=0.5, seed=SEED, debug=True)
+    # model = CNN().to(device, memory_format=torch.channels_last)
+    model = BitboardTransformer().to(device, memory_format=torch.channels_last)
     print(model)
 
     loss_fn = nn.MSELoss()
@@ -43,7 +44,7 @@ def main():
             train_p=0.7,
             val_p=0.15,
             test_p=0.15,
-            batch_size=2**13,
+            batch_size=2**11,
             shuffle=True,
             device=device,
             mixed_precision=True,

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -34,7 +34,7 @@ def main():
     print(model)
 
     loss_fn = nn.MSELoss()
-    optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+    optimizer = torch.optim.Adam(model.parameters(), betas=(0.9, 0.999), weight_decay=0.0, lr=1e-3)
 
     training_loop = TrainingLoop(
             model,
@@ -44,7 +44,7 @@ def main():
             train_p=0.7,
             val_p=0.15,
             test_p=0.15,
-            batch_size=2**11,
+            batch_size=2**13,
             shuffle=True,
             device=device,
             mixed_precision=True,

--- a/src/training.py
+++ b/src/training.py
@@ -1,38 +1,8 @@
-import pkbar # progress bar for pytorch
 import torch
 from torch.utils.data import DataLoader
 from torch.optim.lr_scheduler import LinearLR, ReduceLROnPlateau
 from datasets.utils import split_dataset
 from contextlib import ExitStack
-
-class TrainingCallback():
-    """ Training Callback base class """
-    def __init__():
-        pass
-
-    def on_train_batch_start(self, state):
-        pass
-
-    def on_train_batch_end(self, state):
-        pass
-
-    def on_train_epoch_start(self, state):
-        pass
-
-    def on_train_epoch_end(self, state):
-        pass
-
-    def on_validation_batch_start(self, state):
-        pass
-
-    def on_validation_batch_end(self, state):
-        pass
-
-    def on_validation_start(self, state):
-        pass
-
-    def on_validation__end(self, state):
-        pass
 
 class TrainingLoop():
     def __init__(self,
@@ -48,6 +18,7 @@ class TrainingLoop():
                  device='cpu',
                  mixed_precision=False,
                  callbacks=[],
+                 metrics=[],
                  verbose=1,
                  seed=42):
         self.model = model
@@ -62,8 +33,17 @@ class TrainingLoop():
         self.device = device
         self.mixed_precision = mixed_precision
         self.verbose = verbose
-        self.callbacks=callbacks
+        self.callbacks = callbacks
+        self.metrics = dict.fromkeys(metrics)
         self.seed = 42
+
+        # Internal training state
+        self.state = {}
+
+    def _clear_state(self):
+        """ Clear internal training state """
+        self.state['epoch'] = None
+        self.state['lr'] = None
 
     def _init_dataloaders(self):
         # TODO: maybe use an other class for evaluation?
@@ -72,7 +52,6 @@ class TrainingLoop():
                 self.train_p,
                 self.val_p,
                 self.test_p)
-
 
     def _make_dataloaders(self, dataset, train_p, val_p, test_p):
         train_ds, val_ds, test_ds = split_dataset(dataset,
@@ -99,30 +78,25 @@ class TrainingLoop():
                 num_workers=0)
         return train_dl, val_dl, test_dl
 
-
     def _train(self, epochs):
+        self._clear_state()
         self._init_dataloaders()
+        num_batches = len(self.train_dataloader)
+        self.update_state('batches', num_batches)
+        
+        self.on_train_start()
 
         # Pytorch auto scaler for mixed precision training
         if self.mixed_precision:
             scaler = torch.cuda.amp.GradScaler()
 
-        total_steps = 1000
-        lr_warmup = LinearLR(self.optimizer, start_factor=0.001, total_iters=total_steps)
-        lr_decay = ReduceLROnPlateau(self.optimizer, mode='min', factor=0.5, patience=10)
-
-        num_batches = len(self.train_dataloader)
         for epoch in range(epochs):
-            ################################### Initialization ########################################
-            kbar = pkbar.Kbar(target=num_batches, epoch=epoch, num_epochs=epochs, width=20, always_stateful=False, stateful_metrics=['lr'])
-            # By default, all metrics are averaged over time. If you don't want this behavior, you could either:
-            # 1. Set always_stateful to True, or
-            # 2. Set stateful_metrics=["loss", "rmse", "val_loss", "val_rmse"], Metrics in this list will be displayed as-is.
-            # All others will be averaged by the progbar before display.
-            ###########################################################################################
+            self.update_state('epoch', epoch)
+            self.on_train_epoch_start()
 
             self.model.train()
             for batch, (X, aux, y) in enumerate(self.train_dataloader):
+                self.update_state('batch', batch)
                 # TODO: generalize variable type
                 X = X.float().to(self.device, non_blocking=True, memory_format=torch.channels_last)
                 y = y.float().to(self.device, non_blocking=True)
@@ -147,18 +121,14 @@ class TrainingLoop():
                     loss.backward()
                     self.optimizer.step()
 
-                lr_warmup.step()
-                kbar.update(batch, values=[('loss', loss), ('lr', lr_warmup.get_last_lr()[0])])
-
+                self.update_metric('loss', loss)
+                self.on_train_batch_end()
 
             val_loss = self._test(self.val_dataloader)
+            self.update_metric('val_loss', val_loss)
+            self.on_validation_end()
 
-            if epoch * num_batches > total_steps:
-                lr_decay.step(val_loss)
-
-            ################################ Add validation metrics ###################################
-            kbar.add(1, values=[('val_loss', val_loss)])
-            ###########################################################################################
+        self.on_train_end()
 
     def _test(self, dataloader):
         num_batches = len(dataloader)
@@ -184,6 +154,51 @@ class TrainingLoop():
         del self.train_dataloader
         del self.val_dataloader
         del self.test_dataloader
+        self._clear_stae()
+
+    def get_last_metric(self, metric):
+        """ Get last computed metric """
+        return self.metrics.get(metric, None)
+
+    def update_metric(self, metric, value):
+        self.metrics[metric] = value
+
+    def update_state(self, key, value):
+        self.state[key] = value
+
+    def get_state(self, key):
+        return self.state.get(key, None)
+
+    """ Callback hooks """
+    def on_train_start(self):
+        for c in self.callbacks: c.on_train_start(self)
+
+    def on_train_end(self):
+        for c in self.callbacks: c.on_train_end(self)
+
+    def on_train_batch_start(self):
+        for c in self.callbacks: c.on_train_batch_start(self)
+
+    def on_train_batch_end(self):
+        for c in self.callbacks: c.on_train_batch_end(self)
+
+    def on_train_epoch_start(self):
+        for c in self.callbacks: c.on_train_epoch_start(self)
+
+    def on_train_epoch_end(self):
+        for c in self.callbacks: c.on_train_epoch_end(self)
+
+    def on_validation_batch_start(self):
+        for c in self.callbacks: c.on_validation_batch_start(self)
+
+    def on_validation_batch_end(self):
+        for c in self.callbacks: c.on_validation_batch_end(self)
+
+    def on_validation_start(self):
+        for c in self.callbacks: c.on_validation_start(self)
+
+    def on_validation_end(self):
+        for c in self.callbacks: c.on_validation_end(self)
 
     # TODO: maybe use an other class for evaluation?
     def evaluate(self):

--- a/src/training.py
+++ b/src/training.py
@@ -176,6 +176,16 @@ class TrainingLoop():
         self._train(epochs)
         return self.model
 
+    def clear(self):
+        del self.train_dataloader
+        del self.val_dataloader
+        del self.test_dataloader
+        self.train_dataloader, self.val_dataloader, self.test_dataloader = self._make_dataloaders(
+                self.dataset,
+                self.train_p,
+                self.val_p,
+                self.test_p)
+
     # TODO: maybe use an other class for evaluation?
     def evaluate(self):
         pass

--- a/src/training.py
+++ b/src/training.py
@@ -65,12 +65,14 @@ class TrainingLoop():
         self.callbacks=callbacks
         self.seed = 42
 
+    def _init_dataloaders(self):
         # TODO: maybe use an other class for evaluation?
         self.train_dataloader, self.val_dataloader, self.test_dataloader = self._make_dataloaders(
                 self.dataset,
                 self.train_p,
                 self.val_p,
                 self.test_p)
+
 
     def _make_dataloaders(self, dataset, train_p, val_p, test_p):
         train_ds, val_ds, test_ds = split_dataset(dataset,
@@ -99,6 +101,8 @@ class TrainingLoop():
 
 
     def _train(self, epochs):
+        self._init_dataloaders()
+
         # Pytorch auto scaler for mixed precision training
         if self.mixed_precision:
             scaler = torch.cuda.amp.GradScaler()
@@ -180,11 +184,6 @@ class TrainingLoop():
         del self.train_dataloader
         del self.val_dataloader
         del self.test_dataloader
-        self.train_dataloader, self.val_dataloader, self.test_dataloader = self._make_dataloaders(
-                self.dataset,
-                self.train_p,
-                self.val_p,
-                self.test_p)
 
     # TODO: maybe use an other class for evaluation?
     def evaluate(self):

--- a/src/training.py
+++ b/src/training.py
@@ -154,7 +154,7 @@ class TrainingLoop():
         del self.train_dataloader
         del self.val_dataloader
         del self.test_dataloader
-        self._clear_stae()
+        self._clear_state()
 
     def get_last_metric(self, metric):
         """ Get last computed metric """

--- a/src/training.py
+++ b/src/training.py
@@ -72,7 +72,6 @@ class TrainingLoop():
             scaler = torch.cuda.amp.GradScaler()
 
         num_batches = len(self.train_dataloader)
-        self.model.train()
         for epoch in range(epochs):
             ################################### Initialization ########################################
             kbar = pkbar.Kbar(target=num_batches, epoch=epoch, num_epochs=epochs, width=20, always_stateful=False)
@@ -82,6 +81,7 @@ class TrainingLoop():
             # All others will be averaged by the progbar before display.
             ###########################################################################################
 
+            self.model.train()
             for batch, (X, aux, y) in enumerate(self.train_dataloader):
                 # TODO: generalize variable type
                 X = X.float().to(self.device, non_blocking=True, memory_format=torch.channels_last)

--- a/src/training.py
+++ b/src/training.py
@@ -160,6 +160,9 @@ class TrainingLoop():
         """ Get last computed metric """
         return self.metrics.get(metric, None)
 
+    def get_last_metrics(self):
+        return self.metrics.copy()
+
     def update_metric(self, metric, value):
         self.metrics[metric] = value
 
@@ -168,6 +171,9 @@ class TrainingLoop():
 
     def get_state(self, key):
         return self.state.get(key, None)
+
+    def get_states(self):
+        return self.state.copy()
 
     """ Callback hooks """
     def on_train_start(self):


### PR DESCRIPTION
Feature changes and new implementations:

* Basic vision transformer (ViT) implementation: basically copied from lucidrains/vit-pytorch
* Multiprocessing-based dataset allocation (avoids memory leaks and useless retention)
* Defined a basic custom callback architecture inside TrainingLoop with multiple hooks for different training and validation phases
* Implemented Learning rate scheduler as a TrainingCallback with linear warmup and decay on plateau
* Implemented the progress bar as a TrainingCallback, decoupling TrainingLoop from logging
* Implemented Weights & Biases callback (WandbCallback) which logs states and metrics across epochs (and optionally batches)
* Used a configuration dictionary to store hyperparameters and log them indo wandb
* Switched to RAdam: it seems to be more stable with bigger architectures
* Run the code as a jupyter notebook inside docker for quicker experimentation (no need to reload the dataset each time)