### PR TITLE
Random subsampling

### DIFF
--- a/src/datasets/utils.py
+++ b/src/datasets/utils.py
@@ -1,6 +1,23 @@
 import torch
-from torch.utils.data import random_split
+from torch.utils.data import random_split, Sampler, Dataset
+from torch.utils.data.dataset import Subset
+from typing import Sized, Iterator
+import numpy as np
+import random
+from torch import default_generator, randperm
+from torch._utils import _accumulate
 
+def my_random_split(dataset, lengths, generator = default_generator):
+    """ same as torch.utils.data.random_split, but passes a `ndarray` to Subset
+    in order to avoid memory leaks caused by python refcounting behaviour of
+    native lists
+    """
+    # Cannot verify that dataset is Sized
+    if sum(lengths) != len(dataset):    # type: ignore[arg-type]
+        raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
+
+    indices = np.array(randperm(sum(lengths), generator=generator).tolist())
+    return [Subset(dataset, indices[offset - length : offset]) for offset, length in zip(_accumulate(lengths), lengths)]
 
 def split_dataset(ds, train_p=0.7, val_p=0.15, test_p=0.15, seed=42):
     """ Split a torch.utils.data.Datset into 3 random split, according to the
@@ -19,9 +36,27 @@ def split_dataset(ds, train_p=0.7, val_p=0.15, test_p=0.15, seed=42):
     val_size = int(len(ds) * val_p)
     test_size = len(ds) - train_size - val_size
 
-    train_ds, val_ds, test_ds = random_split(ds,
+    train_ds, val_ds, test_ds = my_random_split(ds,
             [train_size, val_size, test_size],
             generator=torch.Generator().manual_seed(seed)
             )
+
     # for clarity
     return train_ds, val_ds, test_ds
+
+class RandomSubsetSampler(Sampler[int]):
+    def __init__(self, data_source: Sized, fraction: int, replace=False) -> None:
+        self.fraction = fraction
+        self.data_source = data_source
+        self.replace = replace
+
+    def __iter__(self) -> Iterator[int]:
+        n = len(self.data_source)
+        if not self.replace:
+            yield from iter(np.random.choice(n, int(n*self.fraction), replace=False))
+        else:
+            for i in range(int(n * self.fraction)):
+                yield np.random.randint(low=0, high=n)
+
+    def __len__(self) -> int:
+        return int(len(self.data_source) * self.fraction)

--- a/src/napoleonzero-torch.py
+++ b/src/napoleonzero-torch.py
@@ -177,6 +177,7 @@ def main():
             'test-split-perc': 0.0025,
             'batch-size': batch_size,
             'shuffle': False,
+            'random-subsampling': 0.1,
             'mixed-precision': True,
             }
 
@@ -260,6 +261,7 @@ def main():
             test_p=config['test-split-perc'],
             batch_size=config['batch-size'],
             shuffle=config['shuffle'],
+            random_subsampling=config['random-subsampling'],
             filter_fn=partial(filter_scores, filter_threshold),
             device=device,
             mixed_precision=config['mixed-precision'],

--- a/src/training.py
+++ b/src/training.py
@@ -6,7 +6,6 @@ from datasets.utils import split_dataset
 from contextlib import ExitStack
 import numpy as np
 import gc
-from datasets.FilteredDataset import FilteredSampler, FilteredBatchSampler
 
 class TrainingLoop():
     def __init__(self,


### PR DESCRIPTION
- RandomSubsetSampler implements random sampling with/without replacement
with a given sample size
- fix memory leak caused by torch.utils.data.random_split which creates
Subset datasets by passing indices lists. Each element of such lists
holds its own refcount, which causes copy-on-access behaviour while
indexing the list with many forked processes. A solution is to use numpy
arrays which only have one refcount, thus not causing memory issues when
accessed by multiple processes.