### PR TITLE
Implement Win-Draw-Loss loss function

### DIFF
--- a/src/losses/WDLLoss.py
+++ b/src/losses/WDLLoss.py
@@ -1,0 +1,15 @@
+import torch
+from torch import nn
+from torch.nn import BCELoss, BCEWithLogitsLoss
+
+class WDLLoss(nn.Module):
+    """ Implements Win-Draw-Loss loss function"""
+    def __init__(self, input_scale: float = 410.0, target_scale: float = 410.0):
+        super().__init__()
+        self.input_scale = input_scale
+        self.target_scale = target_scale
+        self.bce = BCEWithLogitsLoss()
+
+    def forward(self, input, target):
+        return self.bce(input / self.input_scale, torch.sigmoid(target / self.target_scale))
+

--- a/src/losses/__init__.py
+++ b/src/losses/__init__.py
@@ -1,1 +1,2 @@
 from .MSRELoss import MSRELoss
+from .WDLLoss import WDLLoss


### PR DESCRIPTION
`WDDLoss` is a simple wrapper around `BCEWithLogitsLoss` that maps the centipawn target score to the [0, 1] interval